### PR TITLE
Support configuring database connect timeout, with 5 second default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+## v1.1.0 (2020-02-14)
+
 * Add support for configuring database connection timeout, with 5 second default
 
 ## v1.0.0 (2019-04-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Add support for configuring database connection timeout, with 5 second default
+
 ## v1.0.0 (2019-04-03)
 
 * Drop php5 support

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ return [
             'username' => 'me',
             'password' => 'sesame',
         ],
-        // 'charset' => 'utf8' (this is the default if not specified)
+        // 'charset'         => 'utf8' (this is the default if not specified)
+        // 'timeout_seconds' => 5 (this is the default if not specified)
     ]
 ];
 ```

--- a/src/Dependency/ConnectionConfigProvider.php
+++ b/src/Dependency/ConnectionConfigProvider.php
@@ -20,7 +20,7 @@ class ConnectionConfigProvider
     protected $config;
 
     /**
-     * 
+     *
      * @param array $config e.g. the connection group from the database connection config.
      *                      [NB] it is not expected to be valid for this to be empty at runtime, but allowing a null
      *                      value allows us to create an instance in development / test environments without full
@@ -30,14 +30,15 @@ class ConnectionConfigProvider
     {
         $this->config = \array_merge(
             [
-                'type'       => 'MySQL',
-                'connection' => [
+                'type'            => 'MySQL',
+                'connection'      => [
                     'hostname' => NULL,
                     'database' => NULL,
                     'username' => NULL,
                     'password' => NULL,
                 ],
-                'charset'    => 'utf8',
+                'charset'         => 'utf8',
+                'timeout_seconds' => 5,
             ],
             $config ?: []
         );
@@ -68,12 +69,15 @@ class ConnectionConfigProvider
         }
 
         return [
-            'driver'   => 'pdo_mysql',
-            'host'     => $this->config['connection']['hostname'],
-            'user'     => $this->config['connection']['username'],
-            'password' => $this->config['connection']['password'],
-            'dbname'   => $this->config['connection']['database'],
-            'charset'  => $this->config['charset'],
+            'driver'        => 'pdo_mysql',
+            'host'          => $this->config['connection']['hostname'],
+            'user'          => $this->config['connection']['username'],
+            'password'      => $this->config['connection']['password'],
+            'dbname'        => $this->config['connection']['database'],
+            'charset'       => $this->config['charset'],
+            'driverOptions' => [
+                \PDO::ATTR_TIMEOUT => $this->config['timeout_seconds'],
+            ],
         ];
 
     }

--- a/test/integration/Dependency/DoctrineFactoryTest.php
+++ b/test/integration/Dependency/DoctrineFactoryTest.php
@@ -62,15 +62,26 @@ class DoctrineFactoryTest extends TestCase
     /**
      * @dataProvider provider_expected_services
      */
-    public function test_it_can_configure_all_published_services($key, $expect_class, $expect_shared)
-    {
+    public function test_it_can_configure_all_published_services(
+        $key,
+        $expect_class,
+        $expect_shared
+    ) {
         $container = $this->newContainer(DoctrineFactory::definitions());
         $service   = $container->get($key);
         $this->assertInstanceOf($expect_class, $service);
         if ($expect_shared) {
-            $this->assertSame($service, $container->get($key), 'Container should provide same service');
+            $this->assertSame(
+                $service,
+                $container->get($key),
+                'Container should provide same service'
+            );
         } else {
-            $this->assertNotSame($service, $container->get($key), 'Container should provide different services');
+            $this->assertNotSame(
+                $service,
+                $container->get($key),
+                'Container should provide different services'
+            );
         }
     }
 
@@ -94,8 +105,16 @@ class DoctrineFactoryTest extends TestCase
         $this->assertInstanceOf($expect, $cache);
         $config = $container->get('doctrine.config.orm_config');
         /** @var Configuration $config */
-        $this->assertSame($cache, $config->getMetadataCacheImpl(), 'Should use compiler cache for metadata');
-        $this->assertSame($cache, $config->getQueryCacheImpl(), 'Should use compiler cache for parsed queries');
+        $this->assertSame(
+            $cache,
+            $config->getMetadataCacheImpl(),
+            'Should use compiler cache for metadata'
+        );
+        $this->assertSame(
+            $cache,
+            $config->getQueryCacheImpl(),
+            'Should use compiler cache for parsed queries'
+        );
     }
 
     public function provider_expected_data_cache()
@@ -117,8 +136,15 @@ class DoctrineFactoryTest extends TestCase
         $this->assertInstanceOf(ArrayCache::class, $cache);
         $config = $container->get('doctrine.config.orm_config');
         /** @var Configuration $config */
-        $this->assertSame($cache, $config->getResultCacheImpl(), 'Should use data cache for result caching');
-        $this->assertNull($config->getHydrationCacheImpl(), 'Should not assign hydration cache by default');
+        $this->assertSame(
+            $cache,
+            $config->getResultCacheImpl(),
+            'Should use data cache for result caching'
+        );
+        $this->assertNull(
+            $config->getHydrationCacheImpl(),
+            'Should not assign hydration cache by default'
+        );
     }
 
     public function test_it_attaches_database_config_from_kohana_config()
@@ -141,18 +167,22 @@ class DoctrineFactoryTest extends TestCase
         /** @var ConnectionConfigProvider $cfg */
         $this->assertSame(
             [
-                'driver'   => 'pdo_mysql',
-                'host'     => 'localhost',
-                'user'     => 'me',
-                'password' => 'secret',
-                'dbname'   => 'mydb',
-                'charset'  => 'utf8',
+                'driver'        => 'pdo_mysql',
+                'host'          => 'localhost',
+                'user'          => 'me',
+                'password'      => 'secret',
+                'dbname'        => 'mydb',
+                'charset'       => 'utf8',
+                'driverOptions' => [
+                    \PDO::ATTR_TIMEOUT => 5,
+                ],
             ],
             $cfg->getConnection()
         );
     }
 
-    public function test_it_loads_entity_classes_from_kohana_config_and_can_read_metadata_from_annotations()
+    public function test_it_loads_entity_classes_from_kohana_config_and_can_read_metadata_from_annotations(
+    )
     {
         $this->givenDoctrineConfig(['orm' => ['entity_classes' => [SomeEntity::class]]]);
         $container = $this->newContainer(DoctrineFactory::definitions());
@@ -204,8 +234,11 @@ class DoctrineFactoryTest extends TestCase
     /**
      * @dataProvider provider_proxy_generation
      */
-    public function test_it_configures_proxy_generation_from_defaults_or_from_config_overrides($env, $cfg, $expect)
-    {
+    public function test_it_configures_proxy_generation_from_defaults_or_from_config_overrides(
+        $env,
+        $cfg,
+        $expect
+    ) {
         \Kohana::$environment = $env;
         $this->givenDoctrineConfig($cfg);
         $container = $this->newContainer(DoctrineFactory::definitions());
@@ -233,7 +266,10 @@ class DoctrineFactoryTest extends TestCase
             ]
         );
         $container = $this->newContainer(DoctrineFactory::definitions());
-        $this->assertFalse(Type::hasType('giant_array'), 'Type should not be registered before config');
+        $this->assertFalse(
+            Type::hasType('giant_array'),
+            'Type should not be registered before config'
+        );
         $container->get('doctrine.config.orm_config');
         $this->assertTrue(Type::hasType('giant_array'), 'Type should be registered after config');
         $this->assertInstanceOf(GiantArrayType::class, Type::getType('giant_array'));

--- a/test/unit/Dependency/ConnectionConfigProviderTest.php
+++ b/test/unit/Dependency/ConnectionConfigProviderTest.php
@@ -39,26 +39,45 @@ class ConnectionConfigProviderTest extends TestCase
         $this->assertArraySubset(['driver' => 'pdo_mysql', 'charset' => 'utf8'], $connection);
     }
 
-    public function test_it_parses_config_structure_to_doctrine_connection_config_if_host_configured()
+    public function test_it_has_sane_defaults_for_timeout()
     {
         $this->config = [
-            'type'       => 'MySQL',
             'connection' => [
                 'hostname' => 'localhost',
                 'database' => 'ourdatabase',
                 'username' => 'anyone',
                 'password' => 'anything',
             ],
-            'charset'    => 'cp1212',
+        ];
+        $connection   = $this->newSubject()->getConnection();
+        $this->assertSame(5, $connection['driverOptions'][\PDO::ATTR_TIMEOUT]);
+    }
+
+    public function test_it_parses_config_structure_to_doctrine_connection_config_if_host_configured(
+    )
+    {
+        $this->config = [
+            'type'            => 'MySQL',
+            'connection'      => [
+                'hostname' => 'localhost',
+                'database' => 'ourdatabase',
+                'username' => 'anyone',
+                'password' => 'anything',
+            ],
+            'charset'         => 'cp1212',
+            'timeout_seconds' => 10,
         ];
         $this->assertSame(
             [
-                'driver'   => 'pdo_mysql',
-                'host'     => 'localhost',
-                'user'     => 'anyone',
-                'password' => 'anything',
-                'dbname'   => 'ourdatabase',
-                'charset'  => 'cp1212',
+                'driver'        => 'pdo_mysql',
+                'host'          => 'localhost',
+                'user'          => 'anyone',
+                'password'      => 'anything',
+                'dbname'        => 'ourdatabase',
+                'charset'       => 'cp1212',
+                'driverOptions' => [
+                    \PDO::ATTR_TIMEOUT => 10,
+                ],
             ],
             $this->newSubject()->getConnection()
         );


### PR DESCRIPTION
Can be customised by specifying 'timeout_seconds' => {number}
alongside the connection configuration in config/database.php