### PR TITLE
Restrict doctrine/common and doctrine/persistence versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Unreleased
 
+## v1.1.1 (2020-05-28)
+
+* Restrict doctrine/common and doctrine/persistence versions - the latest minor release of doctrine/orm allows a 
+  breaking release in these packages but we directly use classes and interfaces that have now been renamed.
+
 ## v1.1.0 (2020-02-14)
 
 * Add support for configuring database connection timeout, with 5 second default

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,8 @@
     "composer/installers": "~1.0",
     "ingenerator/kohana-core": "^4.3",
     "doctrine/orm": "^2.5",
+    "doctrine/common": "^2.11",
+    "doctrine/persistence": "^1.3.3",
     "php": "^7.2",
     "ingenerator/kohana-dependencies": "^0.9"
   },


### PR DESCRIPTION
The latest minor release of doctrine/orm allows a breaking release in these packages but we
directly use classes and interfaces that have now been renamed. Pin to the previoius
versions until we support the new interfaces.