### PR TITLE
v3: Migrate from doctrine/cache to symfony/cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 ## v3.0.0 (2024-12-09)
 
 * [BREAKING] Switch to using attributes instead of annotations for mapping
-    - Removes the `ExplicitCallslistAnnotationDriver` class
-    - Removes the `doctrine.config.metadata.reader` service definition
-    - Adds `ExplicitClasslistAttributeDriver` as the default mapping driver
-    - Drops composer dependency on doctrine/annotations
+  - Removes the `ExplicitCallslistAnnotationDriver` class
+  - Removes the `doctrine.config.metadata.reader` service definition
+  - Adds `ExplicitClasslistAttributeDriver` as the default mapping driver
+  - Drops composer dependency on doctrine/annotations
+* [BREAKING] Switch to using PSR-6 cache implementations for metadata, query and result caches:
+  - drops the composer dependency on doctrine/cache in favour of symfony/cache
+  - DoctrineCacheFactory methods are now hard-typehinted to return CacheItemPoolInterface
 * Narrow supported dependency versions to the current latest minor of the suppoerted
   major version.
 * Drop support for PHP < 8.2

--- a/composer.json
+++ b/composer.json
@@ -35,13 +35,13 @@
     "php": "~8.2.0 || ~8.3.0",
     "ext-pdo": "*",
     "composer/installers": "^1.12 || ^2",
-    "doctrine/cache": "^1.13",
     "doctrine/common": "^3.4",
     "doctrine/dbal": "^3.9",
     "doctrine/orm": "^2.20",
     "doctrine/persistence": "^2.5",
     "ingenerator/kohana-core": "^4.12",
-    "ingenerator/kohana-dependencies": "^1.4"
+    "ingenerator/kohana-dependencies": "^1.4",
+    "symfony/cache": "^6.4 || ^7.2"
   },
   "require-dev": {
     "kohana/koharness": "dev-master",

--- a/src/Dependency/DoctrineCacheFactory.php
+++ b/src/Dependency/DoctrineCacheFactory.php
@@ -4,8 +4,10 @@
 namespace Ingenerator\KohanaDoctrine\Dependency;
 
 
-use Doctrine\Common\Cache\ApcuCache;
-use Doctrine\Common\Cache\ArrayCache;
+use Kohana;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class DoctrineCacheFactory
 {
@@ -14,30 +16,29 @@ class DoctrineCacheFactory
      * The data cache is used for query result etc caching.
      *
      * It is always present, but only used if specific queries / operations indicate that they're cacheable. Also by
-     * default it uses an ArrayCache in all environments. This ensures code paths don't need to vary to cope with the
+     * default it uses an ArrayAdapter in all environments. This ensures code paths don't need to vary to cope with the
      * presence / absence of cache. You'll of course want to switch to a suitable persistent cache in projects where
      * you actually want to cache in production.
-     *
-     * @return ArrayCache
      */
-    public static function buildDataCache()
+    public static function buildDataCache(): CacheItemPoolInterface
     {
-        return new ArrayCache;
+        return new ArrayAdapter();
     }
 
     /**
      * The compiler cache is used for metadata and query compilation caching
      *
-     * By default it uses ArrayCache in local development (to ensure changes are picked up live) and
+     * By default it uses ArrayAdapter in local development (to ensure changes are picked up live) and
      * Apcu in all other environments. Note that this cache is tied to the codebase deployed, so can
      * and should be separate on all instances in a cluster, there's no need to swap out for a shared
      * (e.g. memcached) cache when scaling.
-     *
-     * @return ApcuCache|ArrayCache
      */
-    public static function buildCompilerCache()
+    public static function buildCompilerCache(): CacheItemPoolInterface
     {
-        return \Kohana::$environment === \Kohana::DEVELOPMENT ? new ArrayCache : new ApcuCache;
+        return match (\Kohana::$environment) {
+            Kohana::DEVELOPMENT => new ArrayAdapter(),
+            default => new ApcuAdapter('doctrine-meta')
+        };
     }
 
 }

--- a/src/Dependency/DoctrineFactory.php
+++ b/src/Dependency/DoctrineFactory.php
@@ -3,13 +3,13 @@
 namespace Ingenerator\KohanaDoctrine\Dependency;
 
 
-use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Ingenerator\KohanaDoctrine\ExplicitClasslistAttributeDriver;
+use Psr\Cache\CacheItemPoolInterface;
 
 class DoctrineFactory
 {
@@ -187,19 +187,14 @@ class DoctrineFactory
     /**
      * Creates and configures the ORM config
      *
-     * @param MappingDriver $meta_driver
-     * @param Cache         $compiler_cache
-     * @param Cache         $data_cache
-     * @param array|NULL    $config
-     *
      * @return Configuration
      * @throws \Doctrine\DBAL\DBALException
      */
     public static function buildORMConfig(
         MappingDriver $meta_driver,
-        Cache $compiler_cache,
-        Cache $data_cache,
-        array $config = NULL
+        CacheItemPoolInterface $compiler_cache,
+        CacheItemPoolInterface $data_cache,
+        ?array $config = NULL
     ) {
         $config  = \array_merge(
             [
@@ -208,15 +203,15 @@ class DoctrineFactory
                 'proxy_namespace'  => 'DoctrineEntityProxy',
                 'custom_types'     => [],
             ],
-            $config ?: []
+            $config ?? []
         );
         $orm_cfg = new \Doctrine\ORM\Configuration;
         $orm_cfg->setMetadataDriverImpl($meta_driver);
 
         // Configure caches
-        $orm_cfg->setMetadataCacheImpl($compiler_cache);
-        $orm_cfg->setQueryCacheImpl($compiler_cache);
-        $orm_cfg->setResultCacheImpl($data_cache);
+        $orm_cfg->setMetadataCache($compiler_cache);
+        $orm_cfg->setQueryCache($compiler_cache);
+        $orm_cfg->setResultCache($data_cache);
 
         // Configure proxy generation
         $orm_cfg->setProxyDir($config['proxy_dir']);

--- a/test/integration/Dependency/DoctrineFactoryTest.php
+++ b/test/integration/Dependency/DoctrineFactoryTest.php
@@ -4,9 +4,6 @@
 namespace test\integration\Ingenerator\KohanaDoctrine\Dependency;
 
 
-use Doctrine\Common\Cache\ApcuCache;
-use Doctrine\Common\Cache\ArrayCache;
-use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
@@ -22,6 +19,9 @@ use Ingenerator\KohanaDoctrine\Dependency\ConnectionConfigProvider;
 use Ingenerator\KohanaDoctrine\Dependency\DoctrineFactory;
 use Ingenerator\KohanaDoctrine\ExplicitClasslistAttributeDriver;
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class DoctrineFactoryTest extends TestCase
 {
@@ -49,8 +49,8 @@ class DoctrineFactoryTest extends TestCase
     public function provider_expected_services()
     {
         return [
-            ['doctrine.cache.data_cache', Cache::class, TRUE],
-            ['doctrine.cache.compiler_cache', Cache::class, TRUE],
+            ['doctrine.cache.data_cache', CacheItemPoolInterface::class, TRUE],
+            ['doctrine.cache.compiler_cache', CacheItemPoolInterface::class, TRUE],
             ['doctrine.config.connection_config', ConnectionConfigProvider::class, FALSE],
             ['doctrine.config.metadata.driver', ExplicitClasslistAttributeDriver::class, TRUE],
             ['doctrine.config.orm_config', Configuration::class, TRUE],
@@ -89,9 +89,9 @@ class DoctrineFactoryTest extends TestCase
     public function provider_expected_compiler_cache()
     {
         return [
-            [\Kohana::DEVELOPMENT, ArrayCache::class],
-            [\Kohana::STAGING, ApcuCache::class],
-            [\Kohana::PRODUCTION, ApcuCache::class],
+            [\Kohana::DEVELOPMENT, ArrayAdapter::class],
+            [\Kohana::STAGING, ApcuAdapter::class],
+            [\Kohana::PRODUCTION, ApcuAdapter::class],
         ];
     }
 
@@ -108,12 +108,12 @@ class DoctrineFactoryTest extends TestCase
         /** @var Configuration $config */
         $this->assertSame(
             $cache,
-            $config->getMetadataCacheImpl(),
+            $config->getMetadataCache(),
             'Should use compiler cache for metadata'
         );
         $this->assertSame(
             $cache,
-            $config->getQueryCacheImpl(),
+            $config->getQueryCache(),
             'Should use compiler cache for parsed queries'
         );
     }
@@ -134,16 +134,16 @@ class DoctrineFactoryTest extends TestCase
         \Kohana::$environment = $env;
         $container            = $this->newContainer(DoctrineFactory::definitions());
         $cache                = $container->get('doctrine.cache.data_cache');
-        $this->assertInstanceOf(ArrayCache::class, $cache);
+        $this->assertInstanceOf(ArrayAdapter::class, $cache);
         $config = $container->get('doctrine.config.orm_config');
         /** @var Configuration $config */
         $this->assertSame(
             $cache,
-            $config->getResultCacheImpl(),
+            $config->getResultCache(),
             'Should use data cache for result caching'
         );
         $this->assertNull(
-            $config->getHydrationCacheImpl(),
+            $config->getHydrationCache(),
             'Should not assign hydration cache by default'
         );
     }


### PR DESCRIPTION
doctrine/cache is deprecated, although they still use / support it internally we should be moving to a PSR-16 interface. Gone for symfony/cache as we tend to have it anyway.